### PR TITLE
Support projects built with Babel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,9 @@ export default function (babel) {
       },
       CallExpression(path, state) {
         const { opts } = state;
-        const { filename } = (path && path.hub && path.hub.file && path.hub.file.opts) || (state && state.file);
+        const { filename } = (path && path.hub && path.hub.file && path.hub.file.opts)
+          || (state && state.file);
+
         if ((injectedFile && injectedFile !== filename) || cache[filename]) {
           return
         }

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,9 @@ export default function (babel) {
           injectLoaderFn = null
         },
       },
-      CallExpression(path, { opts }) {
-        const { filename } = path.hub.file.opts
+      CallExpression(path, state) {
+        const { opts } = state;
+        const { filename } = (path && path.hub && path.hub.file && path.hub.file.opts) || (state && state.file);
         if ((injectedFile && injectedFile !== filename) || cache[filename]) {
           return
         }


### PR DESCRIPTION
in Babel 7+，will case the error：

`   Module build failed (from ./node_modules/_babel-loader@8.0.6@babel-loader/lib/index.js):
    TypeError: /Users/lidad/code/ais-pyanalyer/src/widget.ts: Cannot read property 'file' of undefined
        at PluginPass.CallExpression (/Users/lidad/code/ais-pyanalyer/node_modules/_babel-plugin-mickey-model-loader@0.3.8@babel-plugin-mickey-model-loader/lib/index.js:40:33)
        at newFn (/Users/lidad/code/ais-pyanalyer/node_modules/_@babel_traverse@7.7.2@@babel/traverse/lib/visitors.js:179:21)
        at NodePath._call (/Users/lidad/code/ais-pyanalyer/node_modules/_@babel_traverse@7.7.2@@babel/traverse/lib/path/context.js:55:20)
`

to fix it, modify CallExpression function
